### PR TITLE
Bringing back SpanningTree.cognateFileInput

### DIFF
--- a/src/babel/spanningtrees/CognateData.java
+++ b/src/babel/spanningtrees/CognateData.java
@@ -23,12 +23,12 @@ public class CognateData {
 		return cognateGlossMap.get(GlossID);
 	}
 	
-	void loadCognateData(NexusBlockParser nexusFile) throws Exception {
+	void loadCognateData(NexusBlockParser nexusFile, CharstatelabelParser charstatelabels) throws Exception {
 		System.err.println("Loading " + nexusFile);
 		mapGlossIDtoMeaningClassName = new HashMap<Integer, String>();
 		cognateGlossMap = new HashMap<Integer, Map<Integer,Cognate>>();
 
-		List<Entry> entries = this.readCognates(nexusFile);
+		List<Entry> entries = this.readCognates(nexusFile, charstatelabels);
 		
 		for (Entry entry : entries) {
 			//Link GlossId to Gloss:
@@ -55,7 +55,7 @@ public class CognateData {
 		}
 	}
 	
-	public List<Entry> readCognates(NexusBlockParser nexus) throws IOException {
+	public List<Entry> readCognates(NexusBlockParser nexus, CharstatelabelParser charstatelabels) throws IOException {
 		List<String> mapPositionToCognate = new ArrayList<>(); // Entries like 'year_747'
 		List<String> mapPositionToGloss = new ArrayList<>(); // Entries like 'year'
 		List<Integer> mapPositionToGlossID = new ArrayList<>();
@@ -63,7 +63,6 @@ public class CognateData {
 		int k = 0;
 		int meaningClassID = 0;
 		String prev = "";
-		CharstatelabelParser charstatelabels = CharstatelabelParser.parseNexus(nexus);
 		for(Charstatelabel label : charstatelabels.labels) {
 			mapPositionToCognate.add(label.meaning + "_" + label.labelId);
 			mapPositionToGloss.add(label.meaning);

--- a/src/babel/spanningtrees/LocationParser.java
+++ b/src/babel/spanningtrees/LocationParser.java
@@ -47,19 +47,23 @@ public class LocationParser {
 		return parser;
 	}
 
+	public static LocationParser parseKMLFile(String sFileName) {
+		return LocationParser.parseKMLFile(new File(sFileName));
+	}
+
 	/**
 	 * This method makes it possible to parse locations from a KML file. It is
 	 * mostly a copy of the former CognateIO.loadKmlFile.
 	 */
-	public static LocationParser parseKMLFile(String sFileName) {
+	public static LocationParser parseKMLFile(File file) {
 		Random rand = new Random(10);
 
-		System.err.println("Loading " + sFileName);
+		System.err.println("Loading " + file.getPath());
 		LocationParser parser = new LocationParser();
 		try {
 			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 			factory.setValidating(false);
-			org.w3c.dom.Document doc = factory.newDocumentBuilder().parse(new File(sFileName));
+			org.w3c.dom.Document doc = factory.newDocumentBuilder().parse(file);
 			doc.normalize();
 
 			// grab styles out of the KML file

--- a/src/babel/spanningtrees/Panel.java
+++ b/src/babel/spanningtrees/Panel.java
@@ -308,9 +308,9 @@ case DRAW_GLOSS:
 		m_fMinLat = m_fMinLat - fOffset;
 	}
 
-	void loadData(NexusBlockParser nexusFile) throws Exception {
+	void loadData(NexusBlockParser nexusFile, CharstatelabelParser charstatelabels) throws Exception {
 		data = new CognateData();
-		data.loadCognateData(nexusFile);
+		data.loadCognateData(nexusFile, charstatelabels);
 		data.calcSpanningTrees(locations);
 		
 		edgecount = new int[CognateIO.NTAX][CognateIO.NTAX];
@@ -398,8 +398,9 @@ case DRAW_GLOSS:
 		Panel pane = new Panel(args);
 		NexusBlockParser nexus = NexusBlockParser.parseFile(NEXUS_FILE);
 		LocationParser locations = LocationParser.parseNexus(nexus);
+		CharstatelabelParser charstatelabels = CharstatelabelParser.parseNexus(nexus);
 		pane.loadLocations(locations);
-		pane.loadData(nexus);
+		pane.loadData(nexus, charstatelabels);
 		pane.loadBGImage(BG_FILE);
 		frame.add(pane);
 		frame.addKeyListener(pane);

--- a/src/babel/spanningtrees/SpanningTree.java
+++ b/src/babel/spanningtrees/SpanningTree.java
@@ -34,7 +34,7 @@ public class SpanningTree extends Runnable {
 		LocationParser locations = LocationParser.parseNexus(nexus);
 		if(locations.getLocationNames().size() == 0){
 			//Only parsing KML if nexus didn't provide locations.
-			locations = LocationParser.parseKMLFile(kmlFileInput.get().getPath());
+			locations = LocationParser.parseKMLFile(kmlFileInput.get());
 		}
 		//Pane setup:
 		pane.loadLocations(locations);

--- a/src/babel/spanningtrees/SpanningTree.java
+++ b/src/babel/spanningtrees/SpanningTree.java
@@ -15,6 +15,7 @@ import beast.core.Runnable;
 public class SpanningTree extends Runnable {
 	public Input<File> nexusFileInput = new Input<>("nexus","nexus file containing cognate data in binary format",Validate.REQUIRED);
 	public Input<File> kmlFileInput = new Input<>("kml", "kml file containing point locations of languages");
+	public Input<File> cognateFileInput = new Input<>("cognate","cognate file listing labels for each column");
 	public Input<File> backgroundFileInput = new Input<>("background","image map in mercator projection used for background", Validate.REQUIRED);
 	public Input<Double> maxDistInput = new Input<>("maximumDistance", "maximum distance to split on", CognateIO.COGNATE_SPLIT_THRESHOLD);
 	
@@ -31,14 +32,23 @@ public class SpanningTree extends Runnable {
 		CognateIO.COGNATE_SPLIT_THRESHOLD = maxDistInput.get();
 		//Parsing data:
 		NexusBlockParser nexus = NexusBlockParser.parseFile(nexusFileInput.get());
-		LocationParser locations = LocationParser.parseNexus(nexus);
-		if(locations.getLocationNames().size() == 0){
-			//Only parsing KML if nexus didn't provide locations.
+
+		LocationParser locations = null;
+		if(kmlFileInput.get() == null){
+			locations = LocationParser.parseNexus(nexus);
+		}else{
 			locations = LocationParser.parseKMLFile(kmlFileInput.get());
+		}
+
+		CharstatelabelParser charstatelabels;
+		if(cognateFileInput.get() == null){
+			charstatelabels = CharstatelabelParser.parseNexus(nexus);
+		}else{
+			charstatelabels = CharstatelabelParser.parseCognateFile(cognateFileInput.get());
 		}
 		//Pane setup:
 		pane.loadLocations(locations);
-		pane.loadData(nexus);
+		pane.loadData(nexus, charstatelabels);
 		pane.loadBGImage(backgroundFileInput.get().getPath());
 		// Frame setup:
 		frame.add(pane);


### PR DESCRIPTION
This PR would bring back the `SpanningTree.cognateFileInput` that I removed on the assumption that me not needing it would imply no one needing it.

I've also adjusted the parsing of the `.kml` and `cognate.dat` files so that the `SpanningTree.run` method looks if any of these is provided and prefers them over data potentially given in the nexus file. This way the user can decide to overwrite the data given in a nexus file.
